### PR TITLE
Feature: CLI flag for unix error code

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Supports emojis.
 
 Logs out where it found the nvmrc file, if one is present. And logs out current node version.
 
+- `-f, --fail`
+
+Process exits with code 1 if node version mismatch.
+
 ```sh
 npx verify-nvmrc -e -v
 # ℹ️ Current node version v14.15.4

--- a/cli.mjs
+++ b/cli.mjs
@@ -49,6 +49,7 @@ async function birdUp() {
 async function main() {
   const args = new Set(process.argv);
   const supportEmojis = args.has("-e") || args.has("--emoji");
+  const exitWithErrorCodeOnFailure = args.has("-f") || args.has("--fail");
 
   const currentNodeVersion = runCommand("node --version");
   const closestNvmrcFile = await birdUp();
@@ -74,6 +75,11 @@ async function main() {
 
   if (currentNodeVersion !== closestNvmrcFile.version) {
     warn(supportEmojis && "🚨", "Node version is NOT correct");
+
+    if (exitWithErrorCodeOnFailure) {
+      // exiting with Unix code 1 indicates error
+      process.exit(1);
+    }
 
     return;
   }


### PR DESCRIPTION
## Context

- our org uses `.nvmrc` files to specify a node version for a particular repo
- we want to detect when local Node version mismatches `.nvmrc` and block subsequent scripts

## Why we need this new flag

- we want to use this script inline such that it blocks subsequent scripts if the check fails:

```js
// package.json
scripts: {
  "example": "npx verify-nvmrc -f && echo "hi"
}
```

- in this example, "hi" won't print if the `.npmrc` check fails 👍 
- this is useful for preventing people from e.g. accidentally starting local dev with the wrong node version

## How to test these changes

- git checkout to this branch
- check your node version `node -v`
- add a `.nvmrc` that _does not_ match your node version:

```sh
# make a new .nvmrc file in project root
echo > .nvmrc v14.0.0    
```

- run the script with the `-f` flag:

```sh
node cli.mjs -f && echo "hi"

# Node version is NOT correct
```

- if `hi` isn't printed in your console, then the new flag works ✔️ 
- don't forget to regression test– ensure old behavior is preserved:

```sh
node cli.mjs && echo "hi"

# Node version is NOT correct
# hi
```